### PR TITLE
Fix bug wherein if the topic is provided as a symbol the associated limits are not correctly loaded.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /pkg/
 /spec/reports/
 /tmp/
+/.idea/
 
 # rspec failure tracking
 .rspec_status

--- a/lib/rate_limit/throttler.rb
+++ b/lib/rate_limit/throttler.rb
@@ -8,7 +8,7 @@ module RateLimit
       @topic     = topic.to_s
       @value     = value.to_i
       @namespace = namespace&.to_s
-      @windows   = Limit.fetch(topic).map { |limit| Window.new(self, limit) }
+      @windows   = Limit.fetch(@topic).map { |limit| Window.new(self, limit) }
     end
 
     def perform!

--- a/spec/rate_limit/throttler_spec.rb
+++ b/spec/rate_limit/throttler_spec.rb
@@ -1,15 +1,20 @@
 # frozen_string_literal: true
 
 RSpec.describe RateLimit::Throttler do
-  let(:topic_login) { 'login' }
+  let(:sym_topic) { :login }
+  let(:topic_login) { sym_topic.to_s }
   let(:namespace_user_id) { 'user_id' }
   let(:value_five) { 5 }
   let(:options) do
     {
-      topic: topic_login,
+      topic: sym_topic,
       namespace: namespace_user_id,
       value: value_five
     }
+  end
+
+  before do
+    allow(RateLimit::Config::FileLoader).to receive(:fetch).and_return({ topic_login => { 2 => 300 } })
   end
 
   describe '.new' do
@@ -116,7 +121,7 @@ RSpec.describe RateLimit::Throttler do
         end
 
         it 'error interval to equal 60' do
-          expect(error.interval).to eq(60)
+          expect(error.interval).to eq(300)
         end
       end
     end


### PR DESCRIPTION
<!-- Please delete any unused headings -->

## Description

The bug is caused by the shadowing of topic variable (we are using the local variable expecting the instance variable). explicitly calling the instance variable fixes it.

## PR Contains:

- [ ] Documentation
- [x] Tests
- [ ] Breaking Changes

## Changelog

<!-- List the changes requested by this PR -->
<!-- See guide https://keepachangelog.com/en/1.0.0/ -->

### Changed
- changed RateLimit::Throttler.initialize to use string topic names during windows initialization

### Fixed

- Loading limits when the topic is a symbol instead of a string.