### PR TITLE
Add `rate-limit.rb` thus fixing automatic requiring of the gem by bundler.

### DIFF
--- a/.rubocop/base.yml
+++ b/.rubocop/base.yml
@@ -20,3 +20,6 @@ RSpec/NestedGroups:
 
 RSpec/MultipleMemoizedHelpers:
   Max: 6
+
+Naming/FileName:
+  Exclude: ['lib/rate-limit.rb']

--- a/lib/rate-limit.rb
+++ b/lib/rate-limit.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require 'rate_limit'


### PR DESCRIPTION
<!-- Please delete any unused headings -->

## Description
Add `rate-limit.rb` and thus fix automatic requiring of the gem by bundler.

## PR Contains:

- [ ] Documentation
- [ ] Tests
- [ ] Breaking Changes

## Related Issues

* fixes https://github.com/catawiki/rate-limit/issues/6
<!-- Link github action in "<action> [issue_id]" format  -->
<!-- i.e. "resloves #1" -->
<!-- See guide https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## Changelog

<!-- List the changes requested by this PR -->
<!-- See guide https://keepachangelog.com/en/1.0.0/ -->

### Added

- Added `rate-limit.rb`

### Changed

- changed rubocop config to ignore `rate-limit.rb` for naming layout cop.

### Fixed

- https://github.com/catawiki/rate-limit/issues/6