### PR TITLE
Add Result Class

### DIFF
--- a/lib/rate_limit.rb
+++ b/lib/rate_limit.rb
@@ -2,6 +2,7 @@
 
 require 'active_support/core_ext/module'
 require_relative 'rate_limit/configurable'
+require_relative 'rate_limit/result'
 require_relative 'rate_limit/cache'
 require_relative 'rate_limit/window'
 require_relative 'rate_limit/throttler'

--- a/lib/rate_limit/result.rb
+++ b/lib/rate_limit/result.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module RateLimit
+  class Result
+    # Attributes
+    attr_accessor :topic, :namespace, :value, :threshold, :interval
+
+    # Methods
+    def initialize(worker, success)
+      @topic      = worker.topic
+      @namespace  = worker.namespace
+      @value      = worker.value
+      @threshold  = worker.exceeded_window&.threshold
+      @interval   = worker.exceeded_window&.interval
+      @success    = success
+    end
+
+    def success?
+      @success
+    end
+  end
+end

--- a/lib/rate_limit/throttler.rb
+++ b/lib/rate_limit/throttler.rb
@@ -2,7 +2,7 @@
 
 module RateLimit
   class Throttler
-    attr_accessor :topic, :namespace, :value, :limits, :windows
+    attr_accessor :topic, :namespace, :value, :limits, :windows, :exceeded_window
 
     def initialize(topic:, value:, namespace: nil)
       @topic     = topic.to_s
@@ -49,7 +49,7 @@ module RateLimit
     private
 
     def validate_limit!
-      exceeded_window = Window.find_exceeded(windows)
+      @exceeded_window = Window.find_exceeded(windows)
 
       raise Errors::LimitExceededError, exceeded_window if exceeded_window
     end

--- a/spec/rate_limit/config_spec.rb
+++ b/spec/rate_limit/config_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe RateLimit::Config do
     subject(:config) { described_class.new }
 
     it 'returns instance redis by default' do
-      expect(config.redis).to be_kind_of(Redis)
+      expect(config.redis).to be_a(Redis)
     end
 
     it 'returns fail_safe' do

--- a/spec/rate_limit/configurable_spec.rb
+++ b/spec/rate_limit/configurable_spec.rb
@@ -5,11 +5,11 @@ RSpec.shared_examples_for RateLimit::Configurable do
     subject(:config) { described_class.config }
 
     it 'returns config class' do
-      expect(config).to be_kind_of(described_class::Config)
+      expect(config).to be_a(described_class::Config)
     end
 
     it 'returns instance redis by default' do
-      expect(config.redis).to be_kind_of(Redis)
+      expect(config.redis).to be_a(Redis)
     end
   end
 

--- a/spec/rate_limit/result_spec.rb
+++ b/spec/rate_limit/result_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+RSpec.describe RateLimit::Result do
+  let(:topic_login) { :login }
+  let(:namespace_user_id) { 'user_id' }
+  let(:value_five) { 5 }
+  let(:worker) { RateLimit::Throttler.new(topic: topic_login, namespace: namespace_user_id, value: value_five) }
+
+  describe '.new' do
+    subject(:result) { described_class.new(worker, true) }
+
+    it { expect(result.topic).to eq(worker.topic) }
+    it { expect(result.namespace).to eq(worker.namespace) }
+    it { expect(result.value).to eq(worker.value) }
+    it { expect(result.threshold).to be_nil }
+    it { expect(result.interval).to be_nil }
+    it { expect(result.success?).to be(true) }
+  end
+end

--- a/spec/rate_limit/throttler_spec.rb
+++ b/spec/rate_limit/throttler_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe RateLimit::Throttler do
   end
 
   before do
-    allow(RateLimit::Config::FileLoader).to receive(:fetch).and_return({ topic_login => { 2 => 300 } })
+    allow(RateLimit.config).to receive(:raw_limits).and_return({ topic_login => { 2 => 300 } })
   end
 
   describe '.new' do


### PR DESCRIPTION
<!-- Please delete any unused headings -->

## Description

This PR adds `RateLimit::Result` Class which will be retuned by the interface in the following steps.

## PR Contains:

- [ ] Documentation
- [x] Tests
- [ ] Breaking Changes

## Related Issues

<!-- Link github action in "<action> [issue_id]" format  -->
<!-- i.e. "resloves #1" -->
<!-- See guide https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
- see https://github.com/catawiki/rate-limit/issues/9

## Changelog

<!-- List the changes requested by this PR -->
<!-- See guide https://keepachangelog.com/en/1.0.0/ -->


### Added

- added `RateLimit::Result`

### Changed

- expose `RateLimit::Throttler#exceeded_window`