### PR TITLE
Add success/failure callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,14 @@ RateLimit.configure do |config|
   config.default_interval  = 60
   config.default_threshold = 2
   config.limits_file_path  = 'config/rate-limit.yml'
+  config.on_success = proc { |result|
+    # Success Logic Goes HERE
+    # result.topic, result.namespace, result.value
+  }
+  config.on_failure = proc { |result|
+    # Failure Logic Goes HERE
+    # result.topic, result.namespace, result.value,  result.threshold,  result.interval
+  }
 end
 ```
 

--- a/lib/rate_limit/config.rb
+++ b/lib/rate_limit/config.rb
@@ -9,6 +9,8 @@ module RateLimit
     attr_accessor :default_interval,
                   :default_threshold,
                   :limits_file_path,
+                  :on_success,
+                  :on_failure,
                   :fail_safe,
                   :redis
 
@@ -22,6 +24,14 @@ module RateLimit
 
     def raw_limits_for(topic)
       raw_limits[topic] || Defaults.raw_limits
+    end
+
+    def success_callback(*args)
+      on_success&.call(*args)
+    end
+
+    def failure_callback(*args)
+      on_failure&.call(*args)
     end
 
     private

--- a/lib/rate_limit/worker.rb
+++ b/lib/rate_limit/worker.rb
@@ -34,10 +34,12 @@ module RateLimit
     def success!
       increment_cache_counter
       @result = Result.new(self, true)
+      RateLimit.config.success_callback(result)
     end
 
     def failure!
       @result = Result.new(self, false)
+      RateLimit.config.failure_callback(result)
     end
   end
 end

--- a/spec/rate_limit/config_spec.rb
+++ b/spec/rate_limit/config_spec.rb
@@ -23,5 +23,37 @@ RSpec.describe RateLimit::Config do
     it 'returns limits_file_path' do
       expect(config.limits_file_path).to eq('config/rate-limit.yml')
     end
+
+    it 'returns on_success' do
+      expect(config.on_success).to be_nil
+    end
+
+    it 'returns on_failure' do
+      expect(config.on_failure).to be_nil
+    end
+  end
+
+  describe '#success_callback' do
+    subject(:config) { described_class.new }
+
+    before do
+      config.on_success = proc { |topic| "on_success_#{topic}" }
+    end
+
+    it 'returns topic success_callback' do
+      expect(config.success_callback('topic_name')).to eq('on_success_topic_name')
+    end
+  end
+
+  describe '#failure_callback' do
+    subject(:config) { described_class.new }
+
+    before do
+      config.on_failure = proc { |topic| "on_failure_#{topic}" }
+    end
+
+    it 'returns topic failure_callback' do
+      expect(config.failure_callback('topic_name')).to eq('on_failure_topic_name')
+    end
   end
 end

--- a/spec/rate_limit/result_spec.rb
+++ b/spec/rate_limit/result_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe RateLimit::Result do
   let(:topic_login) { :login }
   let(:namespace_user_id) { 'user_id' }
   let(:value_five) { 5 }
+
   let(:worker) { RateLimit::Worker.new(topic: topic_login, namespace: namespace_user_id, value: value_five) }
 
   describe '.new' do


### PR DESCRIPTION
<!-- Please delete any unused headings -->

## Description

Adds Global success and failure callbacks as suggested in issue https://github.com/catawiki/rate-limit/issues/8

## PR Contains:

- [x] Documentation
- [x] Tests
- [ ] Breaking Changes

## Related Issues

<!-- Link github action in "<action> [issue_id]" format  -->
<!-- i.e. "resloves #1" -->
<!-- See guide https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
- resloves https://github.com/catawiki/rate-limit/issues/8

## Changelog

<!-- List the changes requested by this PR -->
<!-- See guide https://keepachangelog.com/en/1.0.0/ -->

### Added

- added `RateLimit::Config#on_success` and `RateLimit::Config#on_failure` 