### PR TITLE
Remove Namespace Attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Or install it yourself as:
 #### Basic `RateLimit.throttle`
 
 ```ruby
-result = RateLimit.throttle(topic: :login, namespace: :user_id, value: id)
+result = RateLimit.throttle(topic: :login, value: id)
 
 if result.success?
   # Do something
@@ -44,13 +44,12 @@ end
 
 ```ruby
 begin
-  RateLimit.throttle_with_block!(topic: :send_sms, namespace: :user_id, value: id) do
+  RateLimit.throttle_with_block!(topic: :send_sms, value: id) do
     # Logic goes Here
   end
 rescue RateLimit::Errors::LimitExceededError => e
   # Error Handling Logic goes here
   e.topic     # :login
-  e.namespace # :user_id
   e.value     # id
   e.threshold # 2
   e.interval  # 60
@@ -60,7 +59,7 @@ end
 #### Advanced
 
 ```ruby
-worker = RateLimit::Worker.new(topic: :login, namespace: :user_id, value: id)
+worker = RateLimit::Worker.new(topic: :login, value: id)
 
 begin
   worker.throttle_with_block! do
@@ -74,7 +73,7 @@ end
 #### Manual
 
 ```ruby
-worker = RateLimit::Worker.new(topic: :login, namespace: :user_id, value: id)
+worker = RateLimit::Worker.new(topic: :login, value: id)
 
 unless worker.limit_exceeded?
   # Logic goes Here
@@ -87,8 +86,8 @@ end
 
 ```ruby
 begin
-  RateLimit.throttle_with_block!(topic: :send_sms, namespace: :user_id, value: id) do
-    RateLimit.throttle_with_block!(topic: :send_sms, namespace: :phone_number, value: number) do
+  RateLimit.throttle_with_block!(topic: :send_sms_by_id, value: id) do
+    RateLimit.throttle_with_block!(topic: :send_sms_by_phone, value: number) do
       # Logic goes Here
     end
   end
@@ -110,11 +109,11 @@ RateLimit.configure do |config|
   config.limits_file_path  = 'config/rate-limit.yml'
   config.on_success = proc { |result|
     # Success Logic Goes HERE
-    # result.topic, result.namespace, result.value
+    # result.topic, result.value
   }
   config.on_failure = proc { |result|
     # Failure Logic Goes HERE
-    # result.topic, result.namespace, result.value,  result.threshold,  result.interval
+    # result.topic, result.value,  result.threshold,  result.interval
   }
 end
 ```

--- a/lib/rate_limit/errors/limit_exceeded_error.rb
+++ b/lib/rate_limit/errors/limit_exceeded_error.rb
@@ -5,7 +5,7 @@ module RateLimit
     class LimitExceededError < StandardError
       attr_reader :window
 
-      delegate :topic, :namespace, :value, :threshold, :interval, to: :window
+      delegate :topic, :value, :threshold, :interval, to: :window
 
       def initialize(window)
         @window = window
@@ -14,7 +14,7 @@ module RateLimit
       end
 
       def custom_message
-        "#{topic}: #{namespace} has exceeded #{threshold} in #{interval} seconds"
+        "#{topic}: has exceeded #{threshold} in #{interval} seconds"
       end
     end
   end

--- a/lib/rate_limit/result.rb
+++ b/lib/rate_limit/result.rb
@@ -3,12 +3,11 @@
 module RateLimit
   class Result
     # Attributes
-    attr_accessor :topic, :namespace, :value, :threshold, :interval
+    attr_accessor :topic, :value, :threshold, :interval
 
     # Methods
     def initialize(worker, success)
       @topic      = worker.topic
-      @namespace  = worker.namespace
       @value      = worker.value
       @threshold  = worker.exceeded_window&.threshold
       @interval   = worker.exceeded_window&.interval

--- a/lib/rate_limit/window.rb
+++ b/lib/rate_limit/window.rb
@@ -4,7 +4,7 @@ module RateLimit
   class Window
     attr_accessor :worker, :limit
 
-    delegate :topic, :namespace, :value, to: :worker
+    delegate :topic, :value, to: :worker
     delegate :threshold, :interval, to: :limit
 
     def initialize(worker, limit)
@@ -13,7 +13,7 @@ module RateLimit
     end
 
     def key
-      @key ||= [topic, namespace, value, interval].join(':')
+      @key ||= [topic, value, interval].join(':')
     end
 
     def cached_counter

--- a/lib/rate_limit/worker.rb
+++ b/lib/rate_limit/worker.rb
@@ -4,12 +4,11 @@ module RateLimit
   class Worker
     include Throttler
 
-    attr_accessor :topic, :namespace, :value, :limits, :windows, :exceeded_window, :result
+    attr_accessor :topic, :value, :limits, :windows, :exceeded_window, :result
 
-    def initialize(topic:, value:, namespace: nil)
+    def initialize(topic:, value:)
       @topic     = topic.to_s
       @value     = value.to_i
-      @namespace = namespace&.to_s
       @windows   = Window.find_all(worker: self, topic: @topic)
     end
 

--- a/spec/rate_limit/result_spec.rb
+++ b/spec/rate_limit/result_spec.rb
@@ -2,16 +2,14 @@
 
 RSpec.describe RateLimit::Result do
   let(:topic_login) { :login }
-  let(:namespace_user_id) { 'user_id' }
   let(:value_five) { 5 }
 
-  let(:worker) { RateLimit::Worker.new(topic: topic_login, namespace: namespace_user_id, value: value_five) }
+  let(:worker) { RateLimit::Worker.new(topic: topic_login, value: value_five) }
 
   describe '.new' do
     subject(:result) { described_class.new(worker, true) }
 
     it { expect(result.topic).to eq(worker.topic) }
-    it { expect(result.namespace).to eq(worker.namespace) }
     it { expect(result.value).to eq(worker.value) }
     it { expect(result.threshold).to be_nil }
     it { expect(result.interval).to be_nil }

--- a/spec/rate_limit/throttler_spec.rb
+++ b/spec/rate_limit/throttler_spec.rb
@@ -2,7 +2,6 @@
 
 RSpec.shared_examples_for RateLimit::Throttler do
   let(:topic_login) { :login }
-  let(:namespace_user_id) { 'user_id' }
   let(:value_five) { 5 }
 
   before do
@@ -42,7 +41,7 @@ RSpec.shared_examples_for RateLimit::Throttler do
       allow(RateLimit::Window).to receive(:increment_cache_counter).with(any_args).and_call_original
     end
 
-    context 'when namespace attempts did not exceed limits' do
+    context 'when topic attempts did not exceed limits' do
       it 'increments limit in cache when block is not given' do
         subject.throttle
 
@@ -56,7 +55,7 @@ RSpec.shared_examples_for RateLimit::Throttler do
       end
     end
 
-    context 'when namespace attempts exceeds limits' do
+    context 'when topic attempts exceeds limits' do
       before do
         3.times { subject.throttle }
       end
@@ -73,10 +72,6 @@ RSpec.shared_examples_for RateLimit::Throttler do
 
       it 'sets topic to equal login' do
         expect(returned_object.topic).to eq(topic_login.to_s)
-      end
-
-      it 'sets namespace to equal user_id' do
-        expect(returned_object.namespace).to eq(namespace_user_id)
       end
 
       it 'sets value to equal 5' do

--- a/spec/rate_limit/worker_spec.rb
+++ b/spec/rate_limit/worker_spec.rb
@@ -1,15 +1,13 @@
 # frozen_string_literal: true
 
 RSpec.describe RateLimit::Worker do
-  subject(:worker) { described_class.new(topic: topic_login, namespace: namespace_user_id, value: value_five) }
+  subject(:worker) { described_class.new(topic: topic_login, value: value_five) }
 
   let(:topic_login) { :login }
-  let(:namespace_user_id) { 'user_id' }
   let(:value_five) { 5 }
 
   describe '.new' do
     it { expect(worker.topic).to eq(topic_login.to_s) }
-    it { expect(worker.namespace).to eq(namespace_user_id) }
     it { expect(worker.value).to eq(value_five) }
   end
 


### PR DESCRIPTION
<!-- Please delete any unused headings -->

## Description

Deprecating the namespace attribute globally

## PR Contains:

- [x] Documentation
- [x] Tests
- [x] Breaking Changes

## Related Issues

<!-- Link github action in "<action> [issue_id]" format  -->
<!-- i.e. "resloves #1" -->
<!-- See guide https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
- resolves https://github.com/catawiki/rate-limit/issues/18

## Changelog

<!-- List the changes requested by this PR -->
<!-- See guide https://keepachangelog.com/en/1.0.0/ -->

### Removed

- removed `RateLimit::Result#namespace`
- removed `RateLimit::Worker#namespace`
- removed `RateLimit::Errors::LimitExceededError#namespace`
