### PR TITLE
Return Result object in exception

### DIFF
--- a/lib/rate_limit/errors/limit_exceeded_error.rb
+++ b/lib/rate_limit/errors/limit_exceeded_error.rb
@@ -3,18 +3,16 @@
 module RateLimit
   module Errors
     class LimitExceededError < StandardError
-      attr_reader :window
+      attr_reader :result
 
-      delegate :topic, :value, :threshold, :interval, to: :window
-
-      def initialize(window)
-        @window = window
+      def initialize(result)
+        @result = result
 
         super(custom_message)
       end
 
       def custom_message
-        "#{topic}: has exceeded #{threshold} in #{interval} seconds"
+        "#{result.topic}: has exceeded #{result.threshold} in #{result.interval} seconds"
       end
     end
   end

--- a/lib/rate_limit/errors/limit_exceeded_error.rb
+++ b/lib/rate_limit/errors/limit_exceeded_error.rb
@@ -5,6 +5,8 @@ module RateLimit
     class LimitExceededError < StandardError
       attr_reader :result
 
+      delegate :topic, :value, :threshold, :interval, to: :result
+
       def initialize(result)
         @result = result
 

--- a/lib/rate_limit/result.rb
+++ b/lib/rate_limit/result.rb
@@ -17,16 +17,12 @@ module RateLimit
 
     def success!
       @success = true
-      RateLimit.config.success_callback(self)
     end
 
-    def failure!(worker, fail_safe)
+    def failure!(worker)
       @success = false
       @threshold  = worker.exceeded_window&.threshold
       @interval   = worker.exceeded_window&.interval
-      RateLimit.config.failure_callback(self)
-
-      raise Errors::LimitExceededError, self unless fail_safe
     end
   end
 end

--- a/lib/rate_limit/result.rb
+++ b/lib/rate_limit/result.rb
@@ -6,16 +6,27 @@ module RateLimit
     attr_accessor :topic, :value, :threshold, :interval
 
     # Methods
-    def initialize(worker, success)
-      @topic      = worker.topic
-      @value      = worker.value
-      @threshold  = worker.exceeded_window&.threshold
-      @interval   = worker.exceeded_window&.interval
-      @success    = success
+    def initialize(topic:, value:)
+      @topic = topic
+      @value = value
     end
 
     def success?
       @success
+    end
+
+    def success!
+      @success = true
+      RateLimit.config.success_callback(self)
+    end
+
+    def failure!(worker, fail_safe)
+      @success = false
+      @threshold  = worker.exceeded_window&.threshold
+      @interval   = worker.exceeded_window&.interval
+      RateLimit.config.failure_callback(self)
+
+      raise Errors::LimitExceededError, self unless fail_safe
     end
   end
 end

--- a/lib/rate_limit/throttler.rb
+++ b/lib/rate_limit/throttler.rb
@@ -9,10 +9,7 @@ module RateLimit
     end
 
     def throttle_with_block!
-      if reloaded_limit_exceeded?
-        failure!
-        raise Errors::LimitExceededError, exceeded_window
-      end
+      failure!(fail_safe: false) if reloaded_limit_exceeded?
 
       yield
 

--- a/lib/rate_limit/throttler.rb
+++ b/lib/rate_limit/throttler.rb
@@ -9,7 +9,7 @@ module RateLimit
     end
 
     def throttle_with_block!
-      failure!(fail_safe: false) if reloaded_limit_exceeded?
+      failure!(raise_errors: true) if reloaded_limit_exceeded?
 
       yield
 

--- a/lib/rate_limit/worker.rb
+++ b/lib/rate_limit/worker.rb
@@ -34,10 +34,14 @@ module RateLimit
     def success!
       increment_cache_counter
       result.success!
+      RateLimit.config.success_callback(result)
     end
 
     def failure!(fail_safe: true)
-      result.failure!(self, fail_safe)
+      result.failure!(self)
+      RateLimit.config.failure_callback(result)
+
+      raise Errors::LimitExceededError, result unless fail_safe
     end
   end
 end

--- a/lib/rate_limit/worker.rb
+++ b/lib/rate_limit/worker.rb
@@ -10,6 +10,7 @@ module RateLimit
       @topic     = topic.to_s
       @value     = value.to_i
       @windows   = Window.find_all(worker: self, topic: @topic)
+      @result    = Result.new(topic: @topic, value: @value)
     end
 
     def increment_cache_counter
@@ -32,13 +33,11 @@ module RateLimit
 
     def success!
       increment_cache_counter
-      @result = Result.new(self, true)
-      RateLimit.config.success_callback(result)
+      result.success!
     end
 
-    def failure!
-      @result = Result.new(self, false)
-      RateLimit.config.failure_callback(result)
+    def failure!(fail_safe: true)
+      result.failure!(self, fail_safe)
     end
   end
 end

--- a/lib/rate_limit/worker.rb
+++ b/lib/rate_limit/worker.rb
@@ -37,11 +37,11 @@ module RateLimit
       RateLimit.config.success_callback(result)
     end
 
-    def failure!(fail_safe: true)
+    def failure!(raise_errors: false)
       result.failure!(self)
       RateLimit.config.failure_callback(result)
 
-      raise Errors::LimitExceededError, result unless fail_safe
+      raise Errors::LimitExceededError, result if raise_errors
     end
   end
 end

--- a/spec/rate_limit/result_spec.rb
+++ b/spec/rate_limit/result_spec.rb
@@ -4,15 +4,18 @@ RSpec.describe RateLimit::Result do
   let(:topic_login) { :login }
   let(:value_five) { 5 }
 
-  let(:worker) { RateLimit::Worker.new(topic: topic_login, value: value_five) }
-
   describe '.new' do
-    subject(:result) { described_class.new(worker, true) }
+    subject(:result) { described_class.new(topic: topic_login, value: value_five) }
 
-    it { expect(result.topic).to eq(worker.topic) }
-    it { expect(result.value).to eq(worker.value) }
+    it { expect(result.topic).to eq(topic_login) }
+    it { expect(result.value).to eq(value_five) }
     it { expect(result.threshold).to be_nil }
     it { expect(result.interval).to be_nil }
-    it { expect(result.success?).to be(true) }
+
+    it do
+      result.success!
+
+      expect(result.success?).to be(true)
+    end
   end
 end


### PR DESCRIPTION
<!-- Please delete any unused headings -->

## Description

Return result object from `RateLimit::Errors::LimitExceededError` error

## PR Contains:

- [ ] Documentation
- [ ] Tests
- [ ] Breaking Changes

## Related Issues

<!-- Link github action in "<action> [issue_id]" format  -->
<!-- i.e. "resloves #1" -->
<!-- See guide https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
- resolves https://github.com/catawiki/rate-limit/issues/20

## TODO

- Update Readme before release

## Changelog

<!-- List the changes requested by this PR -->
<!-- See guide https://keepachangelog.com/en/1.0.0/ -->

### Added

- added `RateLimit::Errors::LimitExceededError#result`

### Changed

- changed `RateLimit::Result.initialize`

### Removed

- removed `RateLimit::Errors::LimitExceededError#worker`