### PR TITLE
Respect String Values

### DIFF
--- a/lib/rate_limit/worker.rb
+++ b/lib/rate_limit/worker.rb
@@ -8,7 +8,7 @@ module RateLimit
 
     def initialize(topic:, value:)
       @topic     = topic.to_s
-      @value     = value.to_i
+      @value     = value.to_s
       @windows   = Window.find_all(worker: self, topic: @topic)
       @result    = Result.new(topic: @topic, value: @value)
     end

--- a/spec/rate_limit/throttler_spec.rb
+++ b/spec/rate_limit/throttler_spec.rb
@@ -75,7 +75,7 @@ RSpec.shared_examples_for RateLimit::Throttler do
       end
 
       it 'sets value to equal 5' do
-        expect(returned_object.value).to eq(value_five)
+        expect(returned_object.value).to eq(value_five.to_s)
       end
 
       it 'sets threshold to equal 2' do

--- a/spec/rate_limit/worker_spec.rb
+++ b/spec/rate_limit/worker_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe RateLimit::Worker do
 
   describe '.new' do
     it { expect(worker.topic).to eq(topic_login.to_s) }
-    it { expect(worker.value).to eq(value_five) }
+    it { expect(worker.value).to eq(value_five.to_s) }
   end
 
   it_behaves_like RateLimit::Throttler


### PR DESCRIPTION
<!-- Please delete any unused headings -->

## Description

Enable users to pass string value to the RateLimit interface

## PR Contains:

- [ ] Documentation
- [x] Tests
- [ ] Breaking Changes

## Related Issues

<!-- Link github action in "<action> [issue_id]" format  -->
<!-- i.e. "resloves #1" -->
<!-- See guide https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
- fixes https://github.com/catawiki/rate-limit/issues/16

## Changelog

### Changed

- changed `RateLimit::Worker.initialize` to parse value as String
