### PR TITLE
cache the exceeded window using an expiration timestamp thus making `reloaded_limit_exceeded?` private

### DIFF
--- a/lib/rate_limit/base.rb
+++ b/lib/rate_limit/base.rb
@@ -9,7 +9,7 @@ module RateLimit
     end
 
     def limit_exceeded?(**args)
-      Worker.new(**args).reloaded_limit_exceeded?
+      Worker.new(**args).limit_exceeded?
     end
 
     def reset_counters(**args)

--- a/lib/rate_limit/throttler.rb
+++ b/lib/rate_limit/throttler.rb
@@ -3,7 +3,7 @@
 module RateLimit
   module Throttler
     def throttle
-      return failure! if reloaded_limit_exceeded?
+      return failure! if limit_exceeded?
 
       yield if block_given?
 

--- a/spec/rate_limit/base_spec.rb
+++ b/spec/rate_limit/base_spec.rb
@@ -172,11 +172,11 @@ RSpec.shared_examples_for RateLimit::Base do
           expect(Hash).not_to have_received(:new).with(any_args)
         end
 
-        it 'exceeded limit for atribute 1' do
+        it 'exceeded limit for attribute 1' do
           expect(described_class.limit_exceeded?(**options)).to be(true)
         end
 
-        it 'exceeded limit for atribute 2' do
+        it 'exceeded limit for attribute 2' do
           expect(
             described_class.limit_exceeded?(topic: topic_login, value: value_five)
           ).to be(true)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,16 @@
 # frozen_string_literal: true
 
-require 'active_support/core_ext/kernel'
-require 'rate_limit'
-require 'byebug'
 require 'simplecov'
 
-SimpleCov.start
+SimpleCov.start do
+  add_filter '/spec/'
+
+  enable_coverage :branch
+end
+
+require 'active_support/core_ext/kernel'
+require 'byebug'
+require 'rate_limit'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
<!-- Please delete any unused headings -->

## Description

PR Description goes here!

## PR Contains:

- [ ] Documentation
- [ ] Tests
- [ ] Breaking Changes

## Related Issues

<!-- Link github action in "<action> [issue_id]" format  -->
<!-- i.e. "resloves #1" -->
<!-- See guide https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
- ...

## TODO

- [ ] ...

## Changelog

<!-- List the changes requested by this PR -->
<!-- See guide https://keepachangelog.com/en/1.0.0/ -->

### Added

- ...

### Changed

- ...

### Deprecated

- ...

### Removed

- ...

### Fixed

- ...

### Security

- ...