### PR TITLE
Add Integration Tests

### DIFF
--- a/.rubocop/base.yml
+++ b/.rubocop/base.yml
@@ -21,5 +21,9 @@ RSpec/NestedGroups:
 RSpec/MultipleMemoizedHelpers:
   Max: 6
 
+RSpec/DescribeClass:
+  Exclude:
+    - spec/integration/**/*_spec.rb
+
 Naming/FileName:
   Exclude: ['lib/rate-limit.rb']

--- a/.rubocop/ruby-2.7.yml
+++ b/.rubocop/ruby-2.7.yml
@@ -3,3 +3,6 @@ inherit_from:
 
 AllCops:
   TargetRubyVersion: 2.7
+
+Lint/NonDeterministicRequireOrder:
+  Enabled: false

--- a/lib/rate_limit/throttler.rb
+++ b/lib/rate_limit/throttler.rb
@@ -7,7 +7,7 @@ module RateLimit
 
       yield if block_given?
 
-      return success! unless only_failures
+      success!(skip_increment_cache: only_failures)
     rescue StandardError => e
       success! unless e.is_a?(Errors::LimitExceededError)
       raise e

--- a/lib/rate_limit/worker.rb
+++ b/lib/rate_limit/worker.rb
@@ -33,8 +33,8 @@ module RateLimit
       exceeded_window.present?
     end
 
-    def success!
-      increment_cache_counter
+    def success!(skip_increment_cache: false)
+      increment_cache_counter unless skip_increment_cache
       result.success!
       RateLimit.config.success_callback(result)
     end

--- a/spec/integration/basic_throttle_default_options_spec.rb
+++ b/spec/integration/basic_throttle_default_options_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Basic Throttle with Default Options', type: :integration do
+  subject(:result) { RateLimit.throttle(**default_options) }
+
+  let(:topic_login) { 'login' }
+  let(:value_five) { 5 }
+
+  let(:default_options) { { topic: topic_login, value: value_five } }
+
+  it_behaves_like 'CacheFailure', :get
+
+  context 'when attempts did not exceed limits' do
+    it_behaves_like 'increments cache counter', 1
+    it_behaves_like 'result success'
+    it_behaves_like 'callback success', 1
+  end
+
+  context 'when throttle attempts exceeds limits' do
+    before { 2.times { RateLimit.throttle(**default_options) } }
+
+    it_behaves_like 'increments cache counter', 0
+    it_behaves_like 'result failure'
+    it_behaves_like 'callback failure', 1
+  end
+end

--- a/spec/integration/basic_throttle_default_options_spec.rb
+++ b/spec/integration/basic_throttle_default_options_spec.rb
@@ -10,19 +10,19 @@ RSpec.describe 'Basic Throttle with Default Options', type: :integration do
 
   let(:default_options) { { topic: topic_login, value: value_five } }
 
-  it_behaves_like 'CacheFailure', :get
+  it_behaves_like 'a Cache raises Error', :get
 
   context 'when attempts did not exceed limits' do
-    it_behaves_like 'increments cache counter', 1
-    it_behaves_like 'result success'
-    it_behaves_like 'callback success', 1
+    it_behaves_like 'a throttler increments cache counter', 1
+    it_behaves_like 'a result succeeded'
+    it_behaves_like 'a callback success called', 1
   end
 
   context 'when throttle attempts exceeds limits' do
     before { 2.times { RateLimit.throttle(**default_options) } }
 
-    it_behaves_like 'increments cache counter', 0
-    it_behaves_like 'result failure'
-    it_behaves_like 'callback failure', 1
+    it_behaves_like 'a throttler increments cache counter', 0
+    it_behaves_like 'a result failed'
+    it_behaves_like 'a callback failure called', 1
   end
 end

--- a/spec/integration/block_faulty_throttle_default_options_spec.rb
+++ b/spec/integration/block_faulty_throttle_default_options_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Block Faulty Throttle with Default Options', type: :integration do
+  subject(:result) do
+    RateLimit.throttle(**default_options) { RateLimit::Test::YeildHelper.perform(faulty: true) }
+  end
+
+  let(:topic_login) { 'login' }
+  let(:value_five) { 5 }
+
+  let(:default_options) { { topic: topic_login, value: value_five } }
+
+  it_behaves_like 'CacheFailure', :get
+
+  context 'when attempts did not exceed limits' do
+    it_behaves_like 'increments cache counter', 1
+    it_behaves_like 'raises yeild error'
+    it_behaves_like 'callback success', 1
+  end
+
+  context 'when throttle attempts exceeds limits' do
+    before { 2.times { RateLimit.throttle(**default_options) } }
+
+    it_behaves_like 'increments cache counter', 0
+    it_behaves_like 'result failure'
+    it_behaves_like 'does not call yield'
+    it_behaves_like 'callback failure', 1
+  end
+end

--- a/spec/integration/block_faulty_throttle_default_options_spec.rb
+++ b/spec/integration/block_faulty_throttle_default_options_spec.rb
@@ -12,20 +12,20 @@ RSpec.describe 'Block Faulty Throttle with Default Options', type: :integration 
 
   let(:default_options) { { topic: topic_login, value: value_five } }
 
-  it_behaves_like 'CacheFailure', :get
+  it_behaves_like 'a Cache raises Error', :get
 
   context 'when attempts did not exceed limits' do
-    it_behaves_like 'increments cache counter', 1
-    it_behaves_like 'raises yeild error'
-    it_behaves_like 'callback success', 1
+    it_behaves_like 'a throttler increments cache counter', 1
+    it_behaves_like 'a yield raises error'
+    it_behaves_like 'a callback success called', 1
   end
 
   context 'when throttle attempts exceeds limits' do
     before { 2.times { RateLimit.throttle(**default_options) } }
 
-    it_behaves_like 'increments cache counter', 0
-    it_behaves_like 'result failure'
-    it_behaves_like 'does not call yield'
-    it_behaves_like 'callback failure', 1
+    it_behaves_like 'a throttler increments cache counter', 0
+    it_behaves_like 'a result failed'
+    it_behaves_like 'a yield not called'
+    it_behaves_like 'a callback failure called', 1
   end
 end

--- a/spec/integration/block_faulty_throttle_only_failures_spec.rb
+++ b/spec/integration/block_faulty_throttle_only_failures_spec.rb
@@ -13,20 +13,20 @@ RSpec.describe 'Block Faulty Throttle with only_failures', type: :integration do
   let(:default_options) { { topic: topic_login, value: value_five } }
   let(:options) { default_options.merge(only_failures: true) }
 
-  it_behaves_like 'CacheFailure', :get
+  it_behaves_like 'a Cache raises Error', :get
 
   context 'when attempts did not exceed limits' do
-    it_behaves_like 'increments cache counter', 1
-    it_behaves_like 'raises yeild error'
-    it_behaves_like 'callback success', 1
+    it_behaves_like 'a throttler increments cache counter', 1
+    it_behaves_like 'a yield raises error'
+    it_behaves_like 'a callback success called', 1
   end
 
   context 'when throttle attempts exceeds limits' do
     before { 2.times { RateLimit.throttle(**default_options) } }
 
-    it_behaves_like 'increments cache counter', 0
-    it_behaves_like 'result failure'
-    it_behaves_like 'does not call yield'
-    it_behaves_like 'callback failure', 1
+    it_behaves_like 'a throttler increments cache counter', 0
+    it_behaves_like 'a result failed'
+    it_behaves_like 'a yield not called'
+    it_behaves_like 'a callback failure called', 1
   end
 end

--- a/spec/integration/block_faulty_throttle_only_failures_spec.rb
+++ b/spec/integration/block_faulty_throttle_only_failures_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Block Faulty Throttle with only_failures', type: :integration do
+  subject(:result) do
+    RateLimit.throttle(**options) { RateLimit::Test::YeildHelper.perform(faulty: true) }
+  end
+
+  let(:topic_login) { 'login' }
+  let(:value_five) { 5 }
+
+  let(:default_options) { { topic: topic_login, value: value_five } }
+  let(:options) { default_options.merge(only_failures: true) }
+
+  it_behaves_like 'CacheFailure', :get
+
+  context 'when attempts did not exceed limits' do
+    it_behaves_like 'increments cache counter', 1
+    it_behaves_like 'raises yeild error'
+    it_behaves_like 'callback success', 1
+  end
+
+  context 'when throttle attempts exceeds limits' do
+    before { 2.times { RateLimit.throttle(**default_options) } }
+
+    it_behaves_like 'increments cache counter', 0
+    it_behaves_like 'result failure'
+    it_behaves_like 'does not call yield'
+    it_behaves_like 'callback failure', 1
+  end
+end

--- a/spec/integration/block_faulty_throttle_raise_errors_only_failures_spec.rb
+++ b/spec/integration/block_faulty_throttle_raise_errors_only_failures_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Block Faulty Throttle with raise_errors and only_failures', type: :integration do
+  subject(:result) do
+    RateLimit.throttle(**options) { RateLimit::Test::YeildHelper.perform(faulty: true) }
+  end
+
+  let(:topic_login) { 'login' }
+  let(:value_five) { 5 }
+
+  let(:default_options) { { topic: topic_login, value: value_five } }
+  let(:options) { default_options.merge(raise_errors: true, only_failures: true) }
+
+  it_behaves_like 'CacheFailure', :get
+
+  context 'when attempts did not exceed limits' do
+    it_behaves_like 'increments cache counter', 1
+    it_behaves_like 'raises yeild error'
+    it_behaves_like 'callback success', 1
+  end
+
+  context 'when throttle attempts exceeds limits' do
+    before { 2.times { RateLimit.throttle(**default_options) } }
+
+    it_behaves_like 'does not call yield'
+    it_behaves_like 'callback failure', 1
+  end
+end

--- a/spec/integration/block_faulty_throttle_raise_errors_only_failures_spec.rb
+++ b/spec/integration/block_faulty_throttle_raise_errors_only_failures_spec.rb
@@ -13,18 +13,18 @@ RSpec.describe 'Block Faulty Throttle with raise_errors and only_failures', type
   let(:default_options) { { topic: topic_login, value: value_five } }
   let(:options) { default_options.merge(raise_errors: true, only_failures: true) }
 
-  it_behaves_like 'CacheFailure', :get
+  it_behaves_like 'a Cache raises Error', :get
 
   context 'when attempts did not exceed limits' do
-    it_behaves_like 'increments cache counter', 1
-    it_behaves_like 'raises yeild error'
-    it_behaves_like 'callback success', 1
+    it_behaves_like 'a throttler increments cache counter', 1
+    it_behaves_like 'a yield raises error'
+    it_behaves_like 'a callback success called', 1
   end
 
   context 'when throttle attempts exceeds limits' do
     before { 2.times { RateLimit.throttle(**default_options) } }
 
-    it_behaves_like 'does not call yield'
-    it_behaves_like 'callback failure', 1
+    it_behaves_like 'a yield not called'
+    it_behaves_like 'a callback failure called', 1
   end
 end

--- a/spec/integration/block_faulty_throttle_raise_errors_spec.rb
+++ b/spec/integration/block_faulty_throttle_raise_errors_spec.rb
@@ -13,18 +13,18 @@ RSpec.describe 'Block Faulty Throttle with raise_errors', type: :integration do
   let(:default_options) { { topic: topic_login, value: value_five } }
   let(:options) { default_options.merge(raise_errors: true) }
 
-  it_behaves_like 'CacheFailure', :get
+  it_behaves_like 'a Cache raises Error', :get
 
   context 'when attempts did not exceed limits' do
-    it_behaves_like 'increments cache counter', 1
-    it_behaves_like 'raises yeild error'
-    it_behaves_like 'callback success', 1
+    it_behaves_like 'a throttler increments cache counter', 1
+    it_behaves_like 'a yield raises error'
+    it_behaves_like 'a callback success called', 1
   end
 
   context 'when throttle attempts exceeds limits' do
     before { 2.times { RateLimit.throttle(**default_options) } }
 
-    it_behaves_like 'does not call yield'
-    it_behaves_like 'callback failure', 1
+    it_behaves_like 'a yield not called'
+    it_behaves_like 'a callback failure called', 1
   end
 end

--- a/spec/integration/block_faulty_throttle_raise_errors_spec.rb
+++ b/spec/integration/block_faulty_throttle_raise_errors_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Block Faulty Throttle with raise_errors', type: :integration do
+  subject(:result) do
+    RateLimit.throttle(**options) { RateLimit::Test::YeildHelper.perform(faulty: true) }
+  end
+
+  let(:topic_login) { 'login' }
+  let(:value_five) { 5 }
+
+  let(:default_options) { { topic: topic_login, value: value_five } }
+  let(:options) { default_options.merge(raise_errors: true) }
+
+  it_behaves_like 'CacheFailure', :get
+
+  context 'when attempts did not exceed limits' do
+    it_behaves_like 'increments cache counter', 1
+    it_behaves_like 'raises yeild error'
+    it_behaves_like 'callback success', 1
+  end
+
+  context 'when throttle attempts exceeds limits' do
+    before { 2.times { RateLimit.throttle(**default_options) } }
+
+    it_behaves_like 'does not call yield'
+    it_behaves_like 'callback failure', 1
+  end
+end

--- a/spec/integration/block_throttle_default_options_spec.rb
+++ b/spec/integration/block_throttle_default_options_spec.rb
@@ -12,21 +12,21 @@ RSpec.describe 'Block Throttle with Default Options', type: :integration do
 
   let(:default_options) { { topic: topic_login, value: value_five } }
 
-  it_behaves_like 'CacheFailure', :get
+  it_behaves_like 'a Cache raises Error', :get
 
   context 'when attempts did not exceed limits' do
-    it_behaves_like 'increments cache counter', 1
-    it_behaves_like 'result success'
-    it_behaves_like 'calls yield'
-    it_behaves_like 'callback success', 1
+    it_behaves_like 'a throttler increments cache counter', 1
+    it_behaves_like 'a result succeeded'
+    it_behaves_like 'a yield called'
+    it_behaves_like 'a callback success called', 1
   end
 
   context 'when throttle attempts exceeds limits' do
     before { 2.times { RateLimit.throttle(**default_options) } }
 
-    it_behaves_like 'increments cache counter', 0
-    it_behaves_like 'result failure'
-    it_behaves_like 'does not call yield'
-    it_behaves_like 'callback failure', 1
+    it_behaves_like 'a throttler increments cache counter', 0
+    it_behaves_like 'a result failed'
+    it_behaves_like 'a yield not called'
+    it_behaves_like 'a callback failure called', 1
   end
 end

--- a/spec/integration/block_throttle_default_options_spec.rb
+++ b/spec/integration/block_throttle_default_options_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Block Throttle with Default Options', type: :integration do
+  subject(:result) do
+    RateLimit.throttle(**default_options) { RateLimit::Test::YeildHelper.perform }
+  end
+
+  let(:topic_login) { 'login' }
+  let(:value_five) { 5 }
+
+  let(:default_options) { { topic: topic_login, value: value_five } }
+
+  it_behaves_like 'CacheFailure', :get
+
+  context 'when attempts did not exceed limits' do
+    it_behaves_like 'increments cache counter', 1
+    it_behaves_like 'result success'
+    it_behaves_like 'calls yield'
+    it_behaves_like 'callback success', 1
+  end
+
+  context 'when throttle attempts exceeds limits' do
+    before { 2.times { RateLimit.throttle(**default_options) } }
+
+    it_behaves_like 'increments cache counter', 0
+    it_behaves_like 'result failure'
+    it_behaves_like 'does not call yield'
+    it_behaves_like 'callback failure', 1
+  end
+end

--- a/spec/integration/block_throttle_only_failures_spec.rb
+++ b/spec/integration/block_throttle_only_failures_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Block Throttle with only_failures', type: :integration do
+  subject(:result) do
+    RateLimit.throttle(**options) { RateLimit::Test::YeildHelper.perform }
+  end
+
+  let(:topic_login) { 'login' }
+  let(:value_five) { 5 }
+
+  let(:default_options) { { topic: topic_login, value: value_five } }
+  let(:options) { default_options.merge(only_failures: true) }
+
+  it_behaves_like 'CacheFailure', :get
+
+  context 'when attempts did not exceed limits' do
+    it_behaves_like 'increments cache counter', 0
+    it_behaves_like 'result success'
+    it_behaves_like 'calls yield'
+    it_behaves_like 'callback success', 1
+  end
+
+  context 'when throttle attempts exceeds limits' do
+    before { 2.times { RateLimit.throttle(**default_options) } }
+
+    it_behaves_like 'increments cache counter', 0
+    it_behaves_like 'result failure'
+    it_behaves_like 'does not call yield'
+    it_behaves_like 'callback failure', 1
+  end
+end

--- a/spec/integration/block_throttle_only_failures_spec.rb
+++ b/spec/integration/block_throttle_only_failures_spec.rb
@@ -13,21 +13,21 @@ RSpec.describe 'Block Throttle with only_failures', type: :integration do
   let(:default_options) { { topic: topic_login, value: value_five } }
   let(:options) { default_options.merge(only_failures: true) }
 
-  it_behaves_like 'CacheFailure', :get
+  it_behaves_like 'a Cache raises Error', :get
 
   context 'when attempts did not exceed limits' do
-    it_behaves_like 'increments cache counter', 0
-    it_behaves_like 'result success'
-    it_behaves_like 'calls yield'
-    it_behaves_like 'callback success', 1
+    it_behaves_like 'a throttler increments cache counter', 0
+    it_behaves_like 'a result succeeded'
+    it_behaves_like 'a yield called'
+    it_behaves_like 'a callback success called', 1
   end
 
   context 'when throttle attempts exceeds limits' do
     before { 2.times { RateLimit.throttle(**default_options) } }
 
-    it_behaves_like 'increments cache counter', 0
-    it_behaves_like 'result failure'
-    it_behaves_like 'does not call yield'
-    it_behaves_like 'callback failure', 1
+    it_behaves_like 'a throttler increments cache counter', 0
+    it_behaves_like 'a result failed'
+    it_behaves_like 'a yield not called'
+    it_behaves_like 'a callback failure called', 1
   end
 end

--- a/spec/integration/block_throttle_raise_errors_only_failures_spec.rb
+++ b/spec/integration/block_throttle_raise_errors_only_failures_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Block Throttle with raise_errors and only_failures', type: :integration do
+  subject(:result) do
+    RateLimit.throttle(**options) { RateLimit::Test::YeildHelper.perform }
+  end
+
+  let(:topic_login) { 'login' }
+  let(:value_five) { 5 }
+
+  let(:default_options) { { topic: topic_login, value: value_five } }
+  let(:options) { default_options.merge(raise_errors: true, only_failures: true) }
+
+  it_behaves_like 'CacheFailure', :get
+
+  context 'when attempts did not exceed limits' do
+    it_behaves_like 'increments cache counter', 0
+    it_behaves_like 'result success'
+    it_behaves_like 'calls yield'
+    it_behaves_like 'callback success', 1
+  end
+
+  context 'when throttle attempts exceeds limits' do
+    before { 2.times { RateLimit.throttle(**default_options) } }
+
+    it_behaves_like 'does not call yield'
+    it_behaves_like 'callback failure', 1
+  end
+end

--- a/spec/integration/block_throttle_raise_errors_only_failures_spec.rb
+++ b/spec/integration/block_throttle_raise_errors_only_failures_spec.rb
@@ -13,19 +13,19 @@ RSpec.describe 'Block Throttle with raise_errors and only_failures', type: :inte
   let(:default_options) { { topic: topic_login, value: value_five } }
   let(:options) { default_options.merge(raise_errors: true, only_failures: true) }
 
-  it_behaves_like 'CacheFailure', :get
+  it_behaves_like 'a Cache raises Error', :get
 
   context 'when attempts did not exceed limits' do
-    it_behaves_like 'increments cache counter', 0
-    it_behaves_like 'result success'
-    it_behaves_like 'calls yield'
-    it_behaves_like 'callback success', 1
+    it_behaves_like 'a throttler increments cache counter', 0
+    it_behaves_like 'a result succeeded'
+    it_behaves_like 'a yield called'
+    it_behaves_like 'a callback success called', 1
   end
 
   context 'when throttle attempts exceeds limits' do
     before { 2.times { RateLimit.throttle(**default_options) } }
 
-    it_behaves_like 'does not call yield'
-    it_behaves_like 'callback failure', 1
+    it_behaves_like 'a yield not called'
+    it_behaves_like 'a callback failure called', 1
   end
 end

--- a/spec/integration/block_throttle_raise_errors_spec.rb
+++ b/spec/integration/block_throttle_raise_errors_spec.rb
@@ -13,19 +13,19 @@ RSpec.describe 'Block Throttle with raise_errors', type: :integration do
   let(:default_options) { { topic: topic_login, value: value_five } }
   let(:options) { default_options.merge(raise_errors: true) }
 
-  it_behaves_like 'CacheFailure', :get
+  it_behaves_like 'a Cache raises Error', :get
 
   context 'when attempts did not exceed limits' do
-    it_behaves_like 'increments cache counter', 1
-    it_behaves_like 'result success'
-    it_behaves_like 'calls yield'
-    it_behaves_like 'callback success', 1
+    it_behaves_like 'a throttler increments cache counter', 1
+    it_behaves_like 'a result succeeded'
+    it_behaves_like 'a yield called'
+    it_behaves_like 'a callback success called', 1
   end
 
   context 'when throttle attempts exceeds limits' do
     before { 2.times { RateLimit.throttle(**default_options) } }
 
-    it_behaves_like 'does not call yield'
-    it_behaves_like 'callback failure', 1
+    it_behaves_like 'a yield not called'
+    it_behaves_like 'a callback failure called', 1
   end
 end

--- a/spec/integration/block_throttle_raise_errors_spec.rb
+++ b/spec/integration/block_throttle_raise_errors_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Block Throttle with raise_errors', type: :integration do
+  subject(:result) do
+    RateLimit.throttle(**options) { RateLimit::Test::YeildHelper.perform }
+  end
+
+  let(:topic_login) { 'login' }
+  let(:value_five) { 5 }
+
+  let(:default_options) { { topic: topic_login, value: value_five } }
+  let(:options) { default_options.merge(raise_errors: true) }
+
+  it_behaves_like 'CacheFailure', :get
+
+  context 'when attempts did not exceed limits' do
+    it_behaves_like 'increments cache counter', 1
+    it_behaves_like 'result success'
+    it_behaves_like 'calls yield'
+    it_behaves_like 'callback success', 1
+  end
+
+  context 'when throttle attempts exceeds limits' do
+    before { 2.times { RateLimit.throttle(**default_options) } }
+
+    it_behaves_like 'does not call yield'
+    it_behaves_like 'callback failure', 1
+  end
+end

--- a/spec/rate_limit/base_spec.rb
+++ b/spec/rate_limit/base_spec.rb
@@ -12,7 +12,7 @@ RSpec.shared_examples_for RateLimit::Base do
 
     let(:options) { { topic: topic_login, value: value_five } }
 
-    it_behaves_like 'CacheFailure', :multi
+    it_behaves_like 'a Cache raises Error', :multi
 
     context 'when topic attempts exceed limits' do
       before { described_class.throttle(**options) }
@@ -32,7 +32,7 @@ RSpec.shared_examples_for RateLimit::Base do
 
     let(:options) { { topic: topic_login, value: value_five } }
 
-    it_behaves_like 'CacheFailure', :multi
+    it_behaves_like 'a Cache raises Error', :multi
 
     context 'when topic attempts exceed limits' do
       before { described_class.throttle(**options) }
@@ -52,7 +52,7 @@ RSpec.shared_examples_for RateLimit::Base do
 
     let(:options) { { topic: topic_login, value: value_five } }
 
-    it_behaves_like 'CacheFailure', :get
+    it_behaves_like 'a Cache raises Error', :get
 
     context 'when topic attempts exceed limits' do
       before { 3.times { described_class.throttle(**options) } }
@@ -70,7 +70,7 @@ RSpec.shared_examples_for RateLimit::Base do
 
     let(:options) { { topic: topic_login, value: value_five, raise_errors: raise_errors } }
 
-    it_behaves_like 'CacheFailure', :get
+    it_behaves_like 'a Cache raises Error', :get
 
     context 'when attempts did not exceed limits' do
       before do
@@ -93,7 +93,7 @@ RSpec.shared_examples_for RateLimit::Base do
 
       before { allow(Hash).to receive(:new).with(any_args) }
 
-      it 'calls yield' do
+      it 'a yield called' do
         throttle_with_block
 
         expect(Hash).to have_received(:new).with(0).once
@@ -124,7 +124,7 @@ RSpec.shared_examples_for RateLimit::Base do
       before { allow(Hash).to receive(:new) }
 
       context 'when attempts did not exceed limits' do
-        it 'calls yield' do
+        it 'a yield called' do
           nested_throttle!
 
           expect(Hash).to have_received(:new).once
@@ -176,7 +176,7 @@ RSpec.shared_examples_for RateLimit::Base do
 
     let(:options) { { topic: topic_login, value: value_five, only_failures: true } }
 
-    it_behaves_like 'CacheFailure', :get
+    it_behaves_like 'a Cache raises Error', :get
 
     context 'when topic attempts did not exceed limits' do
       before do
@@ -192,7 +192,7 @@ RSpec.shared_examples_for RateLimit::Base do
 
         before { allow(Hash).to receive(:new) }
 
-        it 'calls yield' do
+        it 'a yield called' do
           throttle_only_failures_with_block
 
           expect(Hash).to have_received(:new).once

--- a/spec/rate_limit/base_spec.rb
+++ b/spec/rate_limit/base_spec.rb
@@ -5,20 +5,6 @@ RSpec.shared_examples_for RateLimit::Base do
   let(:value_five) { 5 }
   let(:raise_errors) { false }
 
-  shared_examples_for 'CacheFailure' do |func_name|
-    before { allow(redis_instance).to receive(func_name).and_raise(::Redis::BaseError) }
-
-    let(:redis_instance) { RateLimit.config.redis = Redis.new }
-
-    context 'when fail_safe is true' do
-      before { RateLimit.config.fail_safe = false }
-
-      after { RateLimit.config.fail_safe = true }
-
-      it { expect { subject }.to raise_error(::Redis::BaseError) }
-    end
-  end
-
   describe '.increment_counters' do
     subject(:increment_counters) do
       described_class.increment_counters(**options)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,3 +20,5 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 end
+
+Dir[File.join(__dir__, 'support', '**', '*.rb')].each { |f| require f }

--- a/spec/support/shared_examples/cache_failure.rb
+++ b/spec/support/shared_examples/cache_failure.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+shared_examples_for 'CacheFailure' do |func_name|
+  before { allow(redis_instance).to receive(func_name).and_raise(::Redis::BaseError) }
+
+  let(:redis_instance) { RateLimit.config.redis = Redis.new }
+
+  context 'when fail_safe is true' do
+    before { RateLimit.config.fail_safe = false }
+
+    after { RateLimit.config.fail_safe = true }
+
+    it { expect { subject }.to raise_error(::Redis::BaseError) }
+  end
+end

--- a/spec/support/shared_examples/cache_failure.rb
+++ b/spec/support/shared_examples/cache_failure.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-shared_examples_for 'CacheFailure' do |func_name|
+RSpec.shared_examples_for 'CacheFailure' do |func_name|
   before { allow(redis_instance).to receive(func_name).and_raise(::Redis::BaseError) }
 
   let(:redis_instance) { RateLimit.config.redis = Redis.new }

--- a/spec/support/shared_examples/cache_failure.rb
+++ b/spec/support/shared_examples/cache_failure.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.shared_examples_for 'CacheFailure' do |func_name|
+RSpec.shared_examples_for 'a Cache raises Error' do |func_name|
   before { allow(redis_instance).to receive(func_name).and_raise(::Redis::BaseError) }
 
   let(:redis_instance) { RateLimit.config.redis = Redis.new }

--- a/spec/support/shared_examples/cache_failure.rb
+++ b/spec/support/shared_examples/cache_failure.rb
@@ -5,7 +5,7 @@ RSpec.shared_examples_for 'CacheFailure' do |func_name|
 
   let(:redis_instance) { RateLimit.config.redis = Redis.new }
 
-  context 'when fail_safe is true' do
+  context 'when fail_safe is disabled' do
     before { RateLimit.config.fail_safe = false }
 
     after { RateLimit.config.fail_safe = true }

--- a/spec/support/shared_examples/callbacks.rb
+++ b/spec/support/shared_examples/callbacks.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples_for 'callback success' do |count|
+  before do
+    allow(RateLimit::Test::CallbackHelper).to receive(:success).with(kind_of(RateLimit::Result)).and_call_original
+
+    RateLimit.config.on_success = proc { |result| RateLimit::Test::CallbackHelper.success(result) }
+  end
+
+  after { RateLimit.config.on_success = nil }
+
+  it do
+    suppress(RateLimit::Test::YeildError) { result }
+
+    expect(RateLimit::Test::CallbackHelper).to have_received(:success).exactly(count).times
+  end
+end
+
+RSpec.shared_examples_for 'callback failure' do |count|
+  before do
+    allow(RateLimit::Test::CallbackHelper).to receive(:failure).with(kind_of(RateLimit::Result)).and_call_original
+
+    RateLimit.config.on_failure = proc { |result| RateLimit::Test::CallbackHelper.failure(result) }
+  end
+
+  after { RateLimit.config.on_failure = nil }
+
+  it do
+    suppress(RateLimit::Test::YeildError) { result }
+
+    expect(RateLimit::Test::CallbackHelper).to have_received(:failure).exactly(count).times
+  end
+end

--- a/spec/support/shared_examples/callbacks.rb
+++ b/spec/support/shared_examples/callbacks.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.shared_examples_for 'callback success' do |count|
+RSpec.shared_examples_for 'a callback success called' do |count|
   before do
     allow(RateLimit::Test::CallbackHelper).to receive(:success).with(kind_of(RateLimit::Result)).and_call_original
 
@@ -16,7 +16,7 @@ RSpec.shared_examples_for 'callback success' do |count|
   end
 end
 
-RSpec.shared_examples_for 'callback failure' do |count|
+RSpec.shared_examples_for 'a callback failure called' do |count|
   before do
     allow(RateLimit::Test::CallbackHelper).to receive(:failure).with(kind_of(RateLimit::Result)).and_call_original
 

--- a/spec/support/shared_examples/callbacks.rb
+++ b/spec/support/shared_examples/callbacks.rb
@@ -10,7 +10,7 @@ RSpec.shared_examples_for 'callback success' do |count|
   after { RateLimit.config.on_success = nil }
 
   it do
-    suppress(RateLimit::Test::YeildError) { result }
+    suppress(StandardError) { result }
 
     expect(RateLimit::Test::CallbackHelper).to have_received(:success).exactly(count).times
   end
@@ -26,7 +26,7 @@ RSpec.shared_examples_for 'callback failure' do |count|
   after { RateLimit.config.on_failure = nil }
 
   it do
-    suppress(RateLimit::Test::YeildError) { result }
+    suppress(StandardError) { result }
 
     expect(RateLimit::Test::CallbackHelper).to have_received(:failure).exactly(count).times
   end

--- a/spec/support/shared_examples/increment_cache_counter.rb
+++ b/spec/support/shared_examples/increment_cache_counter.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples_for 'increments cache counter' do |count|
+  before do
+    allow(RateLimit::Window).to receive(:increment_cache_counter).with(any_args).and_call_original
+  end
+
+  it do
+    suppress(RateLimit::Test::YeildError) { subject }
+
+    expect(RateLimit::Window).to have_received(:increment_cache_counter).exactly(count).time
+  end
+end

--- a/spec/support/shared_examples/increment_cache_counter.rb
+++ b/spec/support/shared_examples/increment_cache_counter.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.shared_examples_for 'increments cache counter' do |count|
+RSpec.shared_examples_for 'a throttler increments cache counter' do |count|
   before do
     allow(RateLimit::Window).to receive(:increment_cache_counter).with(any_args).and_call_original
   end

--- a/spec/support/shared_examples/result.rb
+++ b/spec/support/shared_examples/result.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples_for 'result success' do
+  it do
+    expect(result.success?).to be(true)
+  end
+end
+
+RSpec.shared_examples_for 'result failure' do
+  it do
+    expect(result.success?).to be(false)
+  end
+end

--- a/spec/support/shared_examples/result.rb
+++ b/spec/support/shared_examples/result.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-RSpec.shared_examples_for 'result success' do
+RSpec.shared_examples_for 'a result succeeded' do
   it do
     expect(result.success?).to be(true)
   end
 end
 
-RSpec.shared_examples_for 'result failure' do
+RSpec.shared_examples_for 'a result failed' do
   it do
     expect(result.success?).to be(false)
   end

--- a/spec/support/shared_examples/yeild.rb
+++ b/spec/support/shared_examples/yeild.rb
@@ -14,7 +14,7 @@ RSpec.shared_examples_for 'does not call yield' do
   before { allow(RateLimit::Test::YeildHelper).to receive(:perform).with(any_args).and_call_original }
 
   it do
-    subject
+    suppress(RateLimit::Errors::LimitExceededError) { result }
 
     expect(RateLimit::Test::YeildHelper).not_to have_received(:perform)
   end

--- a/spec/support/shared_examples/yeild.rb
+++ b/spec/support/shared_examples/yeild.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.shared_examples_for 'calls yield' do
+RSpec.shared_examples_for 'a yield called' do
   before { allow(RateLimit::Test::YeildHelper).to receive(:perform).with(any_args).and_call_original }
 
   it do
@@ -10,7 +10,7 @@ RSpec.shared_examples_for 'calls yield' do
   end
 end
 
-RSpec.shared_examples_for 'does not call yield' do
+RSpec.shared_examples_for 'a yield not called' do
   before { allow(RateLimit::Test::YeildHelper).to receive(:perform).with(any_args).and_call_original }
 
   it do
@@ -20,7 +20,7 @@ RSpec.shared_examples_for 'does not call yield' do
   end
 end
 
-RSpec.shared_examples_for 'raises yeild error' do
+RSpec.shared_examples_for 'a yield raises error' do
   before { allow(RateLimit::Test::YeildHelper).to receive(:perform).with(any_args).and_call_original }
 
   it do

--- a/spec/support/shared_examples/yeild.rb
+++ b/spec/support/shared_examples/yeild.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples_for 'calls yield' do
+  before { allow(RateLimit::Test::YeildHelper).to receive(:perform).with(any_args).and_call_original }
+
+  it do
+    subject
+
+    expect(RateLimit::Test::YeildHelper).to have_received(:perform).once
+  end
+end
+
+RSpec.shared_examples_for 'does not call yield' do
+  before { allow(RateLimit::Test::YeildHelper).to receive(:perform).with(any_args).and_call_original }
+
+  it do
+    subject
+
+    expect(RateLimit::Test::YeildHelper).not_to have_received(:perform)
+  end
+end
+
+RSpec.shared_examples_for 'raises yeild error' do
+  before { allow(RateLimit::Test::YeildHelper).to receive(:perform).with(any_args).and_call_original }
+
+  it do
+    expect { subject }.to raise_error(RateLimit::Test::YeildError)
+  end
+end

--- a/spec/support/test_helpers.rb
+++ b/spec/support/test_helpers.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module RateLimit
+  module Test
+    module CallbackHelper
+      def self.success(result); end
+      def self.failure(result); end
+    end
+
+    module YeildHelper
+      def self.perform(faulty: false)
+        raise YeildError if faulty
+      end
+    end
+
+    class YeildError < StandardError; end
+  end
+end


### PR DESCRIPTION
<!-- Please delete any unused headings -->

## Description

In this PR we would like to introduce integration tests. The motivation is to cover all the possible usages of the `RateLimit.throttle` interface

- [x] Basic Throttle with Default Options 
- [x] Block Throttle with Default Options
- [x] Block Faulty Throttle with Default Options
- [x] Block Throttle with raise_errors Option
- [x] Block Faulty Throttle with raise_errors Options
- [x] Block Throttle with only_failures Option
- [x] Block Faulty Throttle with only_failures Options
- [x] Block Throttle with only_failures and raise_errors Option
- [x] Block Faulty Throttle with only_failures and raise_errors Option

## PR Contains:

- [ ] Documentation
- [x] Tests
- [ ] Breaking Changes

## Related Issues

<!-- Link github action in "<action> [issue_id]" format  -->
<!-- i.e. "resloves #1" -->
<!-- See guide https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
- fixes https://github.com/catawiki/rate-limit/issues/29

## Changelog

<!-- List the changes requested by this PR -->
<!-- See guide https://keepachangelog.com/en/1.0.0/ -->

### Added

- integration tests

### Changed
- Changed `Worker#throttle` to call `#success!` with `skip_increment_cache` for `only_failures` case