### PR TITLE
Add Catawiki as author in gemspec

### DIFF
--- a/rate_limit.gemspec
+++ b/rate_limit.gemspec
@@ -5,7 +5,7 @@ require_relative 'lib/rate_limit/version'
 Gem::Specification.new do |spec|
   spec.name          = 'rate-limit'
   spec.version       = RateLimit::VERSION
-  spec.authors       = ['Mohamed Motaweh']
+  spec.authors       = ['Catawiki', 'Mohamed Motaweh']
   spec.email         = ['opensource@catawiki.nl']
 
   spec.summary       = 'A Rate Limiting Gem'


### PR DESCRIPTION
## Description

As part of Catawiki's internal open source working group, we've decided to add Catawiki as owner of all of our public gems.

