### PR TITLE
Activesupport 7.1 compatibility

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.7', '3.0', '3.1']
+        ruby: ['2.7', '3.0', '3.1', '3.2']
     steps:
     - uses: actions/checkout@v3
 
@@ -29,7 +29,7 @@ jobs:
     - name: Run Rspec
       run: bundle exec rspec
 
-    - if: ${{ matrix.ruby == '3.1' }}
+    - if: ${{ matrix.ruby == '3.2' }}
       name: Upload coverage results
       uses: actions/upload-artifact@v3
       with:

--- a/.rubocop/ruby-3.2.yml
+++ b/.rubocop/ruby-3.2.yml
@@ -1,0 +1,14 @@
+inherit_from:
+  - base.yml
+
+AllCops:
+  TargetRubyVersion: 3.2
+
+Gemspec/RequiredRubyVersion:
+  Enabled: false
+
+Naming/BlockForwarding:
+  Enabled: false
+
+Style/HashSyntax:
+  Enabled: false

--- a/lib/rate_limit.rb
+++ b/lib/rate_limit.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-require 'active_support/core_ext/module'
+require 'active_support'
+require 'active_support/core_ext'
+
 require_relative 'rate_limit/configurable'
 require_relative 'rate_limit/result'
 require_relative 'rate_limit/cache'

--- a/lib/rate_limit/config/defaults.rb
+++ b/lib/rate_limit/config/defaults.rb
@@ -13,8 +13,7 @@ module RateLimit
       class << self
         def raw_limits
           {
-            RateLimit.config.default_threshold => \
-              RateLimit.config.default_interval
+            RateLimit.config.default_threshold => RateLimit.config.default_interval
           }
         end
       end

--- a/lib/rate_limit/version.rb
+++ b/lib/rate_limit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RateLimit
-  VERSION = '0.2.1'
+  VERSION = '0.3.0'
 end

--- a/rate_limit.gemspec
+++ b/rate_limit.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activesupport', '>= 5.2', '<= 7.0.4'
+  spec.add_dependency 'activesupport', '>= 5.2', '< 7.2'
   spec.add_dependency 'redis', '>= 3.0.0', '<= 5.1.0'
   spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/spec/support/shared_examples/cache_failure.rb
+++ b/spec/support/shared_examples/cache_failure.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples_for 'a Cache raises Error' do |func_name|
-  before { allow(redis_instance).to receive(func_name).and_raise(::Redis::BaseError) }
+  before { allow(redis_instance).to receive(func_name).and_raise(Redis::BaseError) }
 
   let(:redis_instance) { RateLimit.config.redis = Redis.new }
 
@@ -10,6 +10,6 @@ RSpec.shared_examples_for 'a Cache raises Error' do |func_name|
 
     after { RateLimit.config.fail_safe = true }
 
-    it { expect { subject }.to raise_error(::Redis::BaseError) }
+    it { expect { subject }.to raise_error(Redis::BaseError) }
   end
 end


### PR DESCRIPTION
## Description

rate-limit currently depends on `activesupport >= 5.2, <= 7.0.4`. This PR extends its supported activesupport versions to include 7.1.x

## PR Contains:

- [n/a ] Documentation
- [X] Tests
- [ ] Breaking Changes

## Changelog

## [v0.3.0] - 2024-05-17

### Added

- Support for `activesupport >= 5.2, < 7.2`
