### PR TITLE
Update version

### DIFF
--- a/lib/rate_limit/version.rb
+++ b/lib/rate_limit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RateLimit
-  VERSION = '0.4.0'
+  VERSION = '0.5.0'
 end


### PR DESCRIPTION
## Description

Follow up of https://github.com/catawiki/rate-limit/pull/46: we missed one PR updating `activesupport`. This is also a blocker for integration with cw-shipping.

## PR Contains:

- [ ] Documentation
- [ ] Tests
- [ ] Breaking Changes

## Related Issues

<!-- Link github action in "<action> [issue_id]" format  -->
<!-- i.e. "resloves #1" -->
<!-- See guide https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
- ...

## TODO

- [ ] ...

## Changelog

<!-- List the changes requested by this PR -->
<!-- See guide https://keepachangelog.com/en/1.0.0/ -->

### Added

- ...

### Changed

- ...

### Deprecated

- ...

### Removed

- ...

### Fixed

- ...

### Security

- ...